### PR TITLE
Change enum parsing to use names except for string enums 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,19 +12,17 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: |
+            3.10
+            3.11
+            3.12
       - name: Install
-        run: |
-          pip install hatch
-          pip install .[test]
+        run: pip install hatch .[test]
       - name: Run tests
         run: hatch run test:pytest
       - name: Build dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,23 +10,21 @@ jobs:
     name: "Run tests"
     timeout-minutes: 10
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: |
+            3.10
+            3.11
+            3.12
       - name: Install
-        run: |
-          pip install hatch mypy .[test]
+        run: pip install hatch mypy .[test]
       - name: Run tests
         run: hatch run test:pytest
       - name: Run static checks
         run: hatch run test:mypy startle/
       - name: Coverage
-        if: matrix.python-version == '3.12'
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/color.py
+++ b/examples/color.py
@@ -21,6 +21,7 @@ class Color(str, Enum):
     GREEN_LIKE = "green"
     BLUE_LIKE = "blue"
 
+
 class Verbosity(Enum):
     LOW = 1
     MEDIUM = 2

--- a/examples/color.py
+++ b/examples/color.py
@@ -16,19 +16,26 @@ from rich.console import Console
 from startle import start
 
 
-class Color(Enum):
-    RED = "red"
-    GREEN = "green"
-    BLUE = "blue"
+class Color(str, Enum):
+    RED_LIKE = "red"
+    GREEN_LIKE = "green"
+    BLUE_LIKE = "blue"
+
+class Verbosity(Enum):
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
 
 
 def hi(
     name: str,
-    color: Color = Color.RED,
+    color: Color = Color.RED_LIKE,
     style: Literal["bold", "dim", "italic"] = "bold",
+    verbosity: Verbosity = Verbosity.LOW,
 ) -> None:
     console = Console()
-    console.print(f"[{color.value} {style}]{name}[/]")
+    for _ in range(verbosity.value):
+        console.print(f"[{color.value} {style}]{name}[/]")
 
 
 start(hi)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,10 @@ local_scheme = "no-local-version"
 version-file = "startle/_version.py"
 
 [tool.hatch.envs.test]
-dependencies = [ "pytest", "pytest-cov" ]
+dependencies = [ "pytest", "pytest-cov", "mypy" ]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.10", "3.11", "3.12"]
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "I"]

--- a/startle/args.py
+++ b/startle/args.py
@@ -1,7 +1,7 @@
 import sys
 from dataclasses import dataclass, field
-from typing import Any, Literal
 from enum import Enum
+from typing import Any, Literal
 
 from .arg import Arg, Name
 from .error import ParserConfigError, ParserOptionError
@@ -381,6 +381,7 @@ class Args:
                 return val.value
             try:
                 from enum import StrEnum
+
                 if isinstance(val, StrEnum):
                     return val.value
             except ImportError:

--- a/startle/args.py
+++ b/startle/args.py
@@ -379,14 +379,11 @@ class Args:
         def default_value(val: Any) -> str:
             if isinstance(val, str) and isinstance(val, Enum):
                 return val.value
-            try:
+            if sys.version_info >= (3, 11):
                 from enum import StrEnum
 
                 if isinstance(val, StrEnum):
                     return val.value
-            except ImportError:
-                # low python version, no StrEnum support
-                pass
             if isinstance(val, Enum):
                 return val.name.lower().replace("_", "-")
             return str(val)

--- a/startle/metavar.py
+++ b/startle/metavar.py
@@ -24,11 +24,19 @@ def _get_metavar(type_: type) -> str | list[str]:
     if get_origin(type_) is Literal:
         if all(isinstance(value, str) for value in get_args(type_)):
             return list(get_args(type_))
+    
+    try:
+        from enum import StrEnum
+        if isclass(type_) and issubclass(type_, StrEnum):
+            return [member.value for member in type_]
+    except ImportError:
+        # low python version, no StrEnum support
+        pass
 
-    if isclass(type_) and issubclass(type_, IntEnum):
-        return [str(member.value) for member in type_]
+    if isclass(type_) and issubclass(type_, Enum) and issubclass(type_, str):
+        return [member.value for member in type_]
 
     if isclass(type_) and issubclass(type_, Enum):
-        return [member.value for member in type_]
+        return [member.name.lower().replace("_", "-") for member in type_]
 
     return _METAVARS.get(type_, "val")

--- a/startle/metavar.py
+++ b/startle/metavar.py
@@ -1,4 +1,4 @@
-from enum import Enum, IntEnum
+from enum import Enum
 from inspect import isclass
 from pathlib import Path
 from typing import Literal, get_args, get_origin
@@ -24,9 +24,10 @@ def _get_metavar(type_: type) -> str | list[str]:
     if get_origin(type_) is Literal:
         if all(isinstance(value, str) for value in get_args(type_)):
             return list(get_args(type_))
-    
+
     try:
         from enum import StrEnum
+
         if isclass(type_) and issubclass(type_, StrEnum):
             return [member.value for member in type_]
     except ImportError:

--- a/startle/metavar.py
+++ b/startle/metavar.py
@@ -1,3 +1,4 @@
+import sys
 from enum import Enum
 from inspect import isclass
 from pathlib import Path
@@ -25,14 +26,11 @@ def _get_metavar(type_: type) -> str | list[str]:
         if all(isinstance(value, str) for value in get_args(type_)):
             return list(get_args(type_))
 
-    try:
+    if sys.version_info >= (3, 11):
         from enum import StrEnum
 
         if isclass(type_) and issubclass(type_, StrEnum):
             return [member.value for member in type_]
-    except ImportError:
-        # low python version, no StrEnum support
-        pass
 
     if isclass(type_) and issubclass(type_, Enum) and issubclass(type_, str):
         return [member.value for member in type_]

--- a/startle/value_parser.py
+++ b/startle/value_parser.py
@@ -44,12 +44,17 @@ def _to_path(value: str) -> Path:
 
 def _to_enum(value: str, enum_type: type) -> Enum:
     try:
-        # first convert string to member type, then member type to enum
-        # e.g. member type for IntEnum is int
+        # for StringEnum and (str, Enum) types, use enum value
+        # otherwise use the name of the member
         member_type: type = getattr(enum_type, "_member_type_", object)
-        if member_type is not object:
-            return enum_type(member_type(value))
-        return enum_type(value)
+        if member_type is str or (member_type is object and issubclass(enum_type, str)):
+            return enum_type(value)
+        try:
+            return enum_type[value.upper().replace("-", "_")]
+        except KeyError:
+            raise ParserValueError(
+                f"Cannot parse enum {enum_type.__name__} from `{value}`!"
+            )
     except ValueError as err:
         raise ParserValueError(
             f"Cannot parse enum {enum_type.__name__} from `{value}`!"

--- a/startle/value_parser.py
+++ b/startle/value_parser.py
@@ -6,7 +6,7 @@ import typing
 from enum import Enum
 from inspect import isclass
 from pathlib import Path
-from typing import Any, Callable, Literal
+from typing import Any, Callable, Literal, cast
 
 from ._type_utils import _strip_optional
 from .error import ParserValueError
@@ -50,7 +50,8 @@ def _to_enum(value: str, enum_type: type) -> Enum:
         if member_type is str or (member_type is object and issubclass(enum_type, str)):
             return enum_type(value)
         try:
-            return enum_type[value.upper().replace("-", "_")]
+            enum_type_ = cast(type[Enum], enum_type)
+            return enum_type_[value.upper().replace("-", "_")]
         except KeyError:
             raise ParserValueError(
                 f"Cannot parse enum {enum_type.__name__} from `{value}`!"

--- a/tests/test_parser/test_parse_enum.py
+++ b/tests/test_parser/test_parse_enum.py
@@ -85,18 +85,20 @@ def test_strenum(opt: Opt):
 @mark.parametrize("opt", Opts())
 def test_intenum(opt: Opt):
     class Number(IntEnum):
-        ONE = 1
-        TWO = 2
-        FOUR = 4
+        ONE_LIKE = 1
+        TWO_LIKE = 2
+        FOUR_LIKE = 4
 
     def count(number: Number):
         print(f"Counting {number}.")
 
-    check_args(count, opt("number", ["1"]), [Number.ONE], {})
-    check_args(count, opt("number", ["2"]), [Number.TWO], {})
-    check_args(count, opt("number", ["4"]), [Number.FOUR], {})
-    with raises(ParserValueError, match="Cannot parse enum Number from `3`!"):
-        check_args(count, opt("number", ["3"]), [], {})
+    check_args(count, opt("number", ["one-like"]), [Number.ONE_LIKE], {})
+    check_args(count, opt("number", ["two-like"]), [Number.TWO_LIKE], {})
+    check_args(count, opt("number", ["four-like"]), [Number.FOUR_LIKE], {})
+    with raises(ParserValueError, match="Cannot parse enum Number from `three-like`!"):
+        check_args(count, opt("number", ["three-like"]), [], {})
+    with raises(ParserValueError, match="Cannot parse enum Number from `1`!"):
+        check_args(count, opt("number", ["1"]), [], {})
 
 
 @mark.parametrize("opt", Opts())


### PR DESCRIPTION
This decides on #14 as:
- `Cls(StrEnum)` and `Cls(str, Enum)` are expecting specification based on values of enum members, not keys
- Every other enum type expects spec based on the names (keys) of the members

Fixes #14.