### PR TITLE
Fix some pylance / mypy issues

### DIFF
--- a/startle/_start.py
+++ b/startle/_start.py
@@ -133,9 +133,9 @@ def _start_cmds(
         else:
             raise e
 
+    args: Args | None = None
     try:
         # then, parse the arguments from the CLI
-        args: Args | None = None
         cmd, args, remaining = cmds.get_cmd_parser(cli_args, default=default)
         args.parse(remaining)
 

--- a/startle/_type_utils.py
+++ b/startle/_type_utils.py
@@ -3,7 +3,7 @@ import types
 from typing import Any, Optional, Union, get_args, get_origin
 
 
-def _strip_optional(type_: type):
+def _strip_optional(type_: Any) -> Any:
     """
     Strip the Optional type from a type hint. Given T1 | ... | Tn | None,
     return T1 | ... | Tn.
@@ -20,7 +20,7 @@ def _strip_optional(type_: type):
     return type_
 
 
-def _normalize_type(annotation):
+def _normalize_type(annotation: Any) -> Any:
     """
     Normalize a type annotation by unifying Union and Optional types.
     """
@@ -28,11 +28,11 @@ def _normalize_type(annotation):
     args = get_args(annotation)
     if origin is Union or origin is types.UnionType:
         if type(None) in args:
-            args = [arg for arg in args if arg is not type(None)]
+            args = tuple([arg for arg in args if arg is not type(None)])
             if len(args) == 1:
                 return Optional[args[0]]
             else:
-                return Union[tuple(args + [type(None)])]
+                return Union[args + tuple([type(None)])]
         else:
             return Union[tuple(args)]
     return annotation

--- a/startle/inspect.py
+++ b/startle/inspect.py
@@ -6,6 +6,7 @@ from typing import (
     Callable,
     Iterable,
     Literal,
+    cast,
     get_args,
     get_origin,
 )
@@ -202,6 +203,7 @@ def make_args_from_params(
             container_type = orig
             normalized_annotation = args_[0] if args_ else str
         elif normalized_annotation in [list, tuple, set]:
+            normalized_annotation = cast(type, normalized_annotation)
             nary = True
             container_type = normalized_annotation
             normalized_annotation = str
@@ -211,6 +213,9 @@ def make_args_from_params(
                 f"Unsupported type `{_shorten_type_annotation(param.annotation)}` "
                 f"for parameter `{param_name}` in `{obj_name}`!"
             )
+
+        # the following should hold if normalized_annotation is parsable
+        normalized_annotation = cast(type, normalized_annotation)
 
         arg = Arg(
             name=name,

--- a/startle/metavar.py
+++ b/startle/metavar.py
@@ -2,7 +2,7 @@ import sys
 from enum import Enum
 from inspect import isclass
 from pathlib import Path
-from typing import Literal, get_args, get_origin
+from typing import Any, Literal, get_args, get_origin
 
 from ._type_utils import _strip_optional
 
@@ -15,7 +15,7 @@ _METAVARS: dict[type, str | list[str]] = {
 }
 
 
-def _get_metavar(type_: type) -> str | list[str]:
+def _get_metavar(type_: Any) -> str | list[str]:
     """
     Get the metavar for a type hint.
     If the result is a list, we assume it is a list of possible choices,

--- a/startle/value_parser.py
+++ b/startle/value_parser.py
@@ -48,7 +48,7 @@ def _to_enum(value: str, enum_type: type) -> Enum:
         # otherwise use the name of the member
         member_type: type = getattr(enum_type, "_member_type_", object)
         if member_type is str or (member_type is object and issubclass(enum_type, str)):
-            return enum_type(value)
+            return cast(Enum, enum_type(value))
         try:
             enum_type_ = cast(type[Enum], enum_type)
             return enum_type_[value.upper().replace("-", "_")]
@@ -71,7 +71,7 @@ _PARSERS: dict[type, Callable[[str], Any]] = {
 }
 
 
-def _get_parser(type_: type) -> Callable[[str], Any] | None:
+def _get_parser(type_: Any) -> Callable[[str], Any] | None:
     """
     Get the parser function for a given type.
     """
@@ -102,7 +102,7 @@ def _get_parser(type_: type) -> Callable[[str], Any] | None:
     return None
 
 
-def parse(value: str, type_: type) -> Any:
+def parse(value: str, type_: Any) -> Any:
     """
     Parse or convert a string value to a given type.
     """
@@ -113,7 +113,7 @@ def parse(value: str, type_: type) -> Any:
     raise ParserValueError(f"Unsupported type {type_.__module__}.{type_.__qualname__}!")
 
 
-def is_parsable(type_: type) -> bool:
+def is_parsable(type_: Any) -> bool:
     """
     Check if a type is parsable (supported).
     """


### PR DESCRIPTION
Some annotations of `type` were actually incorrect for general typing constructs that could be generic alias, or union type and the like. Using `types.GenericAlias` etc makes pylance happy but not mypy. Looks like `Any` is something they can both be happy with 🫠.