### PR TITLE
Add `recurse` option

### DIFF
--- a/examples/dice2.py
+++ b/examples/dice2.py
@@ -1,0 +1,47 @@
+"""
+A program to throw dice.
+
+Example invocations:
+    python examples/dice2.py
+    python examples/dice2.py --sides 20 --count 2 --kind pair
+"""
+
+import random
+from dataclasses import dataclass
+from typing import Literal
+
+from startle import start
+
+
+@dataclass
+class Config:
+    """
+    Configuration for the dice program.
+
+    Attributes:
+        sides: The number of sides on the dice.
+        kind: Whether to throw a single die or a pair of dice.
+    """
+
+    sides: int = 6
+    kind: Literal["single", "pair"] = "single"
+
+
+def throw_dice(cfg: Config, count: int = 1) -> None:
+    """
+    Throw dice according to the configuration.
+
+    Args:
+        cfg: The configuration for the dice.
+        count: The number of dice to throw.
+    """
+    if cfg.kind == "single":
+        for _ in range(count):
+            print(random.randint(1, cfg.sides))
+    else:
+        for _ in range(count):
+            print(random.randint(1, cfg.sides), random.randint(1, cfg.sides))
+
+
+if __name__ == "__main__":
+    start(throw_dice, recurse=True)

--- a/startle/arg.py
+++ b/startle/arg.py
@@ -1,9 +1,12 @@
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from .error import ParserConfigError
 from .metavar import _get_metavar
 from .value_parser import parse
+
+if TYPE_CHECKING:
+    from .args import Args
 
 
 @dataclass
@@ -43,6 +46,7 @@ class Arg:
             This is _only_ used for the help string, because dataclass initializers
             already handle getting the default value out of these factories.
         required: Whether the argument is required.
+        args: Child Args object for parsing this Arg, for structured recursive parsing.
     """
 
     name: Name
@@ -59,6 +63,8 @@ class Arg:
     default: Any = None
     default_factory: Callable[[], Any] | None = None
     required: bool = False
+
+    args: "Args | None" = None
 
     _parsed: bool = False  # if this is already parsed
     _value: Any = None  # the parsed value

--- a/startle/inspect.py
+++ b/startle/inspect.py
@@ -256,6 +256,15 @@ def _make_args_from_params(
 def make_args_from_func(
     func: Callable, *, program_name: str = "", recurse: bool | Literal["child"] = False
 ) -> Args:
+    """
+    Create an Args object from a function signature.
+
+    Args:
+        func: The function to create Args from.
+        program_name: The name of the program, for help string.
+        recurse: Whether to recurse into non-parsable types to create sub-Args.
+            "child" is same as True, but it also indicates that this is not the root Args.
+    """
     # Get the signature of the function
     sig = inspect.signature(func)
     params = sig.parameters.items()
@@ -280,6 +289,16 @@ def make_args_from_class(
     brief: str = "",
     recurse: bool | Literal["child"] = False,
 ) -> Args:
+    """
+    Create an Args object from a class's `__init__` signature and docstring.
+
+    Args:
+        cls: The class to create Args from.
+        program_name: The name of the program, for help string.
+        brief: A brief description of the class, for help string.
+        recurse: Whether to recurse into non-parsable types to create sub-Args.
+            "child" is same as True, but it also indicates that this is not the root Args.
+    """
     # TODO: check if cls is a class?
 
     func = cls.__init__  # type: ignore


### PR DESCRIPTION
A first attempt at recursive parsing. Forces children `Args` to be keyword-only, and not have any n-ary or variadic parameters. Option naming is flat, not hierarchical.

Related: #67, #66